### PR TITLE
fix: Initialize QuickBase64 on JS Thread (Android)

### DIFF
--- a/android/src/main/java/com/reactnativequickbase64/QuickBase64Module.java
+++ b/android/src/main/java/com/reactnativequickbase64/QuickBase64Module.java
@@ -12,7 +12,6 @@ class QuickBase64Module extends ReactContextBaseJavaModule {
   }
 
   private static native void initialize(long jsiPtr, String docDir);
-  private static native void destruct();
 
   public QuickBase64Module(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -24,17 +23,9 @@ class QuickBase64Module extends ReactContextBaseJavaModule {
     return "QuickBase64";
   }
 
-  @Override
-  public void initialize() {
-    super.initialize();
-
+  public static void install(ReactApplicationContext context) {
     QuickBase64Module.initialize(
-      this.getReactApplicationContext().getJavaScriptContextHolder().get(),
-      this.getReactApplicationContext().getFilesDir().getAbsolutePath());
-  }
-
-  @Override
-  public void onCatalystInstanceDestroy() {
-    QuickBase64Module.destruct();
+      context.getJavaScriptContextHolder().get(),
+      context.getFilesDir().getAbsolutePath());
   }
 }


### PR DESCRIPTION
Initializes QuickBase64 on the JS-Thread to avoid any race condition or invalid access.

This also means that the user has to manually edit some native Java files to correctly install QuickBase64...