### PR TITLE
Search node_modules recursively

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Paths
+
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['QuickBase64_kotlinVersion']
@@ -26,6 +28,24 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['QuickBase64_' + name]).toInteger()
 }
 
+static def findNodeModules(baseDir) {
+  def basePath = baseDir.toPath().normalize()
+  // Node's module resolution algorithm searches up to the root directory,
+  // after which the base path will be null
+  while (basePath) {
+    def nodeModulesPath = Paths.get(basePath.toString(), "node_modules")
+    def reactNativePath = Paths.get(nodeModulesPath.toString(), "react-native")
+    if (nodeModulesPath.toFile().exists() && reactNativePath.toFile().exists()) {
+      return nodeModulesPath.toString()
+    }
+    basePath = basePath.getParent()
+  }
+  throw new GradleException("MMKV: Failed to find node_modules/ path!")
+}
+
+def nodeModules = findNodeModules(projectDir);
+logger.warn("react-native-quick-base64: node_modules/ found at: ${nodeModules}");
+
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
@@ -41,7 +61,7 @@ android {
         cmake {
             cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-            arguments "-DNODE_MODULES_DIR=${rootDir}/../node_modules"
+            arguments "-DNODE_MODULES_DIR=${nodeModules}"
         }
     }
     
@@ -78,10 +98,7 @@ repositories {
   if (rootProject.ext.has('reactNativeAndroidRoot')) {
     defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
   } else {
-    defaultDir = new File(
-            projectDir,
-            '/../../../node_modules/react-native/android'
-    )
+    defaultDir = file("$nodeModules/react-native/android")
   }
 
   if (defaultDir.exists()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ static def findNodeModules(baseDir) {
     }
     basePath = basePath.getParent()
   }
-  throw new GradleException("MMKV: Failed to find node_modules/ path!")
+  throw new GradleException("react-native-quick-base64: Failed to find node_modules/ path!")
 }
 
 def nodeModules = findNodeModules(projectDir);


### PR DESCRIPTION
Hello Takuya, Thanks for the library. We're using it in a monorepo setup. So, we need to search for `node_modules` in root directory. 

I've added (copy/pasted 😆) the below approach from [react-native-mmkv](https://github.com/mrousavy/react-native-mmkv/blob/master/android/build.gradle#L5) by marc.

Let me know if any changes are required. Also, love your videos ❤️ 