### PR TITLE
chore: fix path in CMakeLists.txt for Windows build

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -4,6 +4,8 @@ set (PACKAGE_NAME "react-native-quick-base64")
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 11)
 
+file(TO_CMAKE_PATH "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp" libPath)
+
 include_directories(
   ../cpp
   "${NODE_MODULES_DIR}/react-native/React"
@@ -13,7 +15,7 @@ include_directories(
 
 add_library(quickbase64 # Library name
   SHARED
-  "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp"
+  ${libPath}
   ../cpp/base64.cpp
   ../cpp/base64.h
   ../cpp/react-native-quick-base64.cpp


### PR DESCRIPTION
uses `TO_CMAKE_PATH` to generate OS specific path

fixes https://github.com/craftzdog/react-native-quick-base64/issues/8
