### PR TITLE
BUG FIX - iOS: crash on hermes reentrancyCheck

### DIFF
--- a/ios/QuickBase64.mm
+++ b/ios/QuickBase64.mm
@@ -24,7 +24,9 @@ RCT_EXPORT_MODULE()
     return;
   }
 
-  installBase64(*(facebook::jsi::Runtime *)cxxBridge.runtime);
+  [bridge dispatchBlock:^{
+    installBase64(*(facebook::jsi::Runtime *)cxxBridge.runtime);
+  } queue:RCTJSThread];
 }
 
 - (void)invalidate {


### PR DESCRIPTION
# BUG FIX - iOS: crash on hermes `reentrancyCheck`
**Description**: iOS app crashes after invoking `installBase64` in `QuickBase64.mm` - see `#7` & `#8` in attached callstack.

```
Thread 1 Queue : com.apple.main-thread (serial)
#0	0x0000000100fb408f in facebook::react::(anonymous namespace)::ReentrancyCheck::before() [inlined] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp:123
#1	0x0000000100fb4085 in facebook::jsi::detail::BeforeCaller<facebook::react::(anonymous namespace)::ReentrancyCheck, void>::before(facebook::react::(anonymous namespace)::ReentrancyCheck&) [inlined] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:424
#2	0x0000000100fb4085 in facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::Around::Around(facebook::react::(anonymous namespace)::ReentrancyCheck&) [inlined] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:749
#3	0x0000000100fb4085 in facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::Around::Around(facebook::react::(anonymous namespace)::ReentrancyCheck&) at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:748
#4	0x0000000100fb266a in facebook::jsi::WithRuntimeDecorator<facebook::react::(anonymous namespace)::ReentrancyCheck, facebook::jsi::Runtime, facebook::jsi::Runtime>::createPropNameIDFromAscii(char const*, unsigned long) at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/decorator.h:553
#5	0x0000000101257bb9 in facebook::jsi::PropNameID::forAscii(facebook::jsi::Runtime&, char const*, unsigned long) [inlined] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/jsi.h:399
#6	0x0000000101257b9a in facebook::jsi::PropNameID::forAscii(facebook::jsi::Runtime&, char const*) [inlined] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/Pods/Headers/Public/React-jsi/jsi/jsi.h:405
#7	0x0000000101257b9a in installBase64(facebook::jsi::Runtime&) at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native-quick-base64/cpp/react-native-quick-base64.cpp:34
#8	0x0000000101257888 in -[QuickBase64 setBridge:] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native-quick-base64/ios/QuickBase64.mm:27
#9	0x00007ff800bcdbad in -[NSObject(NSKeyValueCoding) setValue:forKey:] ()
#10	0x0000000100ee09b1 in -[RCTModuleData setBridgeForInstance] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/React/Base/RCTModuleData.mm:266
#11	0x0000000100ee0743 in -[RCTModuleData setUpInstanceAndBridge:] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/React/Base/RCTModuleData.mm:220
#12	0x0000000100f1543b in RCTUnsafeExecuteOnMainQueueSync at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/React/Base/RCTUtils.m:275
#13	0x0000000100ee13e0 in -[RCTModuleData instance] at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/React/Base/RCTModuleData.mm:400
#14	0x0000000100ec97df in __49-[RCTCxxBridge _prepareModulesWithDispatchGroup:]_block_invoke at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm:1022
#15	0x000000010336dd18 in _dispatch_call_block_and_release ()
#16	0x000000010336ef5b in _dispatch_client_callout ()
#17	0x000000010337fe5c in _dispatch_main_queue_drain ()
#18	0x000000010337f790 in _dispatch_main_queue_callback_4CF ()
#19	0x00007ff800387b1f in __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ ()
#20	0x00007ff800382436 in __CFRunLoopRun ()
#21	0x00007ff8003816a7 in CFRunLoopRunSpecific ()
#22	0x00007ff809cb128a in GSEventRunModal ()
#23	0x000000010ab00ad3 in -[UIApplication _run] ()
#24	0x000000010ab059ef in UIApplicationMain ()
#25	0x0000000100c08d59 in main at /Users/romanpavlov/Documents/sharekey/sharekey_mobile/ios/sharekey/main.m:7
#26	0x0000000102ff72bf in start_sim ()
#27	0x0000000109bcd310 in start ()
```

## Repro steps
1. Build app in release mode


_**Note:** maybe interferes with `Realm-js` in our project, I have not tested if there is a crash in newly created RN project._

**Result**: crash
**Expected Result**: app should work

## Issue cause
I have not found detailed description and have not achieved full understanding of the problem, but in general - Hermes JS engine is thread sensitive and crashes if JS stuff is set up not on JS thread.
Here is some related links:
- fix of the similar crashes in Expo - https://github.com/expo/expo/pull/20506
- issue with discussion of crash on `ReentrancyCheck` - https://github.com/realm/realm-js/issues/4735

## Solution
Run `installBase64` on `RCTJSThread`

## Risks
I don't see any, app works fine with this fix.