### PR TITLE
fix(ci): replace deprecated `set-output` with `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         id: yarn-cache


### PR DESCRIPTION
### GitHub Actions Refactor: Deprecation Warning Resolution

- Updated `set-output` command to `$GITHUB_OUTPUT` in GitHub Actions, resolving a deprecation warning.

PS. For more information (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)