### PR TITLE
fix(ci): update version `checkout` and `cache` for latest version

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -24,13 +24,13 @@ jobs:
       run:
         working-directory: example/ios
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore node_modules from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -52,7 +52,7 @@ jobs:
           working-directory: example/ios
 
       - name: Restore Pods cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             example/ios/Pods


### PR DESCRIPTION
### Update `actions/checkout` and `actions/cache` Versions

This pull request updates the versions of `actions/checkout` and `actions/cache` in the `build-ios.yml` file.

**Changes Made:**
- Updated `actions/checkout@v2` to `actions/checkout@v4`.
- Updated `actions/cache@v2` to `actions/cache@v3`.
