### PR TITLE
Fix: build on React Native 0.74

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -887,7 +887,9 @@ PODS:
     - glog
     - React-debug
   - react-native-quick-base64 (2.1.0):
-    - React
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - React-nativeconfig (0.73.6)
   - React-NativeModulesApple (0.73.6):
     - glog
@@ -1249,7 +1251,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
   React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
   React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-quick-base64: 3a17f587dc0acc34c26d171361e59b00f8a44255
+  react-native-quick-base64: cff21e7f1a145a63da9d71638fa1b592f08b4ef1
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
   React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee
   React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2
@@ -1275,4 +1277,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 91c1a2a7825051fc42c09f60209485d69ba074d7
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3

--- a/react-native-quick-base64.podspec
+++ b/react-native-quick-base64.podspec
@@ -22,9 +22,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
     "USE_HEADERMAP" => "NO",
   }
-  s.xcconfig               = {
-    "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-  }
 
   if defined?(install_modules_dependencies()) != nil
     install_modules_dependencies(s)

--- a/react-native-quick-base64.podspec
+++ b/react-native-quick-base64.podspec
@@ -26,5 +26,10 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
   }
 
-  s.dependency "React"
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s)
+  else
+    s.dependency "React"
+  end
+
 end


### PR DESCRIPTION
### Description

Use install_modules_dependencies if available so we can easily support new react-native versions.

Fixes #33

### Screenshots

![quick-base-64-example-ok](https://github.com/craftzdog/react-native-quick-base64/assets/21174859/3ecc90a0-19a6-4a52-818a-14274a589b18)

![quick-base-64-rn-074-ok](https://github.com/craftzdog/react-native-quick-base64/assets/21174859/588d0df1-5a89-427b-957d-389bfcbc9823)


### Tests

It should work correctly in the example and RN 0.74+


