### PR TITLE
Expose url flag for encoding, removeLinebreaks for decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,29 +28,33 @@ const decoded = atob(base64)
 
 Compatible with [base64-js](https://github.com/beatgammit/base64-js).
 
-### `byteLength(b64: string): number`
+#### `byteLength(b64: string): number`
 
-Takes a base64 string and returns length of byte array
+Takes a base64 string and returns length of byte array.
 
-### `toByteArray(b64: string): Uint8Array`
+#### `toByteArray(b64: string, removeLinebreaks: boolean = false): Uint8Array`
 
-Takes a base64 string and returns a byte array
+Takes a base64 string and returns a byte array.  Optional `removeLinebreaks` removes all `\n` characters.
 
-### `fromByteArray(uint8: Uint8Array): string`
+#### `fromByteArray(uint8: Uint8Array, urlSafe: boolean = false): string`
 
-Takes a byte array and returns a base64 string
+Takes a byte array and returns a base64 string.  Optional `urlSafe` flag `true` allows for use in URLs.
 
-### `btoa(data: string): string`
+#### `btoa(data: string): string`
 
-Encodes a string in base64
+Encodes a string in base64.
 
-### `atob(b64: string): string`
+#### `atob(b64: string): string`
 
-Decodes a base64 encoded string
+Decodes a base64 encoded string.
 
-### `shim()`
+#### `shim()`
 
 Adds `btoa` and `atob` functions to `global`.
+
+#### `trimBase64Padding = (str: string): string`
+
+Trims the `=` padding character(s) off of the end of a base64 encoded string.  Also, for base64url encoded strings, it will trim off the trailing `.` character(s).
 
 ## Contributing
 

--- a/cpp/base64.h
+++ b/cpp/base64.h
@@ -160,7 +160,7 @@ inline RetString encode_mime(String s) {
 
 template <typename RetString, typename String>
 inline RetString encode(String s, bool url) {
-  return base64_encode<RetString>(reinterpret_cast<const unsigned char*>(s.data()), s.size(), url);
+   return base64_encode<RetString>(reinterpret_cast<const unsigned char*>(s.data()), s.size(), url);
 }
 
 } // namespace detail

--- a/cpp/react-native-quick-base64.cpp
+++ b/cpp/react-native-quick-base64.cpp
@@ -38,7 +38,11 @@ void installBase64(jsi::Runtime& jsiRuntime) {
         if(!valueToString(runtime, arguments[0], &str)) {
           return jsi::Value(-1);
         }
-        std::string strBase64 = base64_encode(str);
+        bool url = false;
+        if (arguments[1].isBool()) {
+          url = arguments[1].asBool();
+        }
+        std::string strBase64 = base64_encode(str, url);
 
         return jsi::Value(jsi::String::createFromUtf8(runtime, strBase64));
       }
@@ -55,7 +59,11 @@ void installBase64(jsi::Runtime& jsiRuntime) {
         }
 
         std::string strBase64 = arguments[0].getString(runtime).utf8(runtime);
-        std::string str = base64_decode(strBase64);
+        bool removeLinebreaks = false;
+        if (arguments[1].isBool()) {
+          removeLinebreaks = arguments[1].asBool();
+        }
+        std::string str = base64_decode(strBase64, removeLinebreaks);
 
         jsi::Function arrayBufferCtor = runtime.global().getPropertyAsFunction(runtime, "ArrayBuffer");
         jsi::Object o = arrayBufferCtor.callAsConstructor(runtime, (int)str.length()).getObject(runtime);

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -886,7 +886,7 @@ PODS:
   - React-Mapbuffer (0.73.6):
     - glog
     - React-debug
-  - react-native-quick-base64 (2.1.0):
+  - react-native-quick-base64 (2.1.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1251,7 +1251,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
   React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
   React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-quick-base64: cff21e7f1a145a63da9d71638fa1b592f08b4ef1
+  react-native-quick-base64: d35b481623c0004a82e4f15991a82f411761d95e
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
   React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee
   React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2

--- a/example/src/MochaRNAdapter.ts
+++ b/example/src/MochaRNAdapter.ts
@@ -7,7 +7,7 @@ let only = false;
 
 export const resetRootSuite = (): void => {
   rootSuite = new Mocha.Suite('') as MochaTypes.Suite;
-  rootSuite.timeout(15 * 1000);
+  rootSuite.timeout(30 * 1000); // big-data test can be time-consuming :|
   mochaContext = rootSuite;
 };
 

--- a/example/src/tests/linebreaks.ts
+++ b/example/src/tests/linebreaks.ts
@@ -1,0 +1,22 @@
+import {expect} from 'chai';
+import {toByteArray} from 'react-native-quick-base64';
+import {describe, it} from '../MochaRNAdapter';
+import {mapArr} from './util';
+
+describe('linebreaks', () => {
+  // encoded `one\ntwo\nthree\nfour` in base64 online tool
+  const str = 'b25lCnR3bw==\ndGhyZWUKZm91cg==';
+
+  it('with linebreaks, leave them', () => {
+    expect(() => toByteArray(str)).to.throw(
+      /Input is not valid base64-encoded data/,
+    );
+  });
+
+  it('with linebreaks, remove them', () => {
+    const arr = toByteArray(str, true);
+    const actual = mapArr(arr, (byte: number) => String.fromCharCode(byte));
+    const expected = 'one\ntwothree\nfour';
+    expect(actual).to.equal(expected);
+  });
+});

--- a/example/src/tests/url-safe.ts
+++ b/example/src/tests/url-safe.ts
@@ -1,5 +1,10 @@
 import {expect} from 'chai';
-import {byteLength, toByteArray} from 'react-native-quick-base64';
+import {
+  byteLength,
+  fromByteArray,
+  toByteArray,
+  trimBase64Padding,
+} from 'react-native-quick-base64';
 import {describe, it} from '../MochaRNAdapter';
 
 // from base64-js library's test suite
@@ -22,5 +27,35 @@ describe('url-safe', () => {
     }
 
     expect(actual.length).to.equal(byteLength(str));
+  });
+
+  // test vector string comes from
+  // https://gist.github.com/pedrouid/b4056fd1f754918ddae86b32cf7d803e#aes-gcm---importkey
+  it('encode/decode base64url string w padding', async () => {
+    const expected = 'Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE';
+    const ba = toByteArray(expected);
+    const actual = fromByteArray(ba, true);
+    expect(trimBase64Padding(actual)).to.equal(
+      expected,
+      'base64 encode (url=true, trimmed)',
+    );
+    expect(actual).to.equal(
+      expected + '.',
+      'base64 encode (url=true, not trimmed)',
+    );
+  });
+
+  it('encode/decode base64 string w padding', async () => {
+    const expected = 'Y0zt37HgOx+BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE';
+    const ba = toByteArray(expected);
+    const actual = fromByteArray(ba, false);
+    expect(trimBase64Padding(actual)).to.equal(
+      expected,
+      'base64 encode (url=false, trimmed)',
+    );
+    expect(actual).to.equal(
+      expected + '=',
+      'base64 encode (url=false, not trimmed)',
+    );
   });
 });

--- a/example/src/tests/zero.ts
+++ b/example/src/tests/zero.ts
@@ -14,7 +14,7 @@ const checks: string[] = [
   'ends with a zero\0',
 ];
 
-describe('zero handling', () => {
+describe('zero (\\0)', () => {
   for (let i = 0; i < checks.length; i++) {
     const check = checks[i] as string;
     it(`convert to base64 and back: '${check}'`, async () => {
@@ -31,10 +31,7 @@ describe('zero handling', () => {
 
   const test = (data: Uint8Array, expected: string, descr: string) => {
     it(`known zero values: ${descr}`, async () => {
-      const hex = Buffer.from(data).toString('hex');
-      console.log('hex', hex);
       const actual = fromByteArray(data);
-      console.log('b64str', actual);
       expect(actual).to.equal(expected);
     });
   };
@@ -45,15 +42,15 @@ describe('zero handling', () => {
 
   // zer\0
   const zer0 = new Uint8Array([122, 101, 114, 0]);
-  test(zer0, 'emVyAA==', 'zer\0');
+  test(zer0, 'emVyAA==', 'zer\\0');
 
   // \0er0
   const ero = new Uint8Array([0, 101, 114, 111]);
-  test(ero, 'AGVybw==', '\0ero');
+  test(ero, 'AGVybw==', '\\0ero');
 
   // zer\0_value
   const zer0_value = new Uint8Array([
     122, 101, 114, 0, 95, 118, 97, 108, 117, 101,
   ]);
-  test(zer0_value, 'emVyAF92YWx1ZQ==', 'zer\0_value');
+  test(zer0_value, 'emVyAF92YWx1ZQ==', 'zer\\0_value');
 });

--- a/example/src/tests/zero.ts
+++ b/example/src/tests/zero.ts
@@ -1,0 +1,59 @@
+import {expect} from 'chai';
+import {
+  byteLength,
+  fromByteArray,
+  toByteArray,
+} from 'react-native-quick-base64';
+import {describe, it} from '../MochaRNAdapter';
+import {mapArr, mapStr} from './util';
+
+const checks: string[] = [
+  'no zero',
+  'contains a \0zero somewhere',
+  '\0starts with a zero',
+  'ends with a zero\0',
+];
+
+describe('zero handling', () => {
+  for (let i = 0; i < checks.length; i++) {
+    const check = checks[i] as string;
+    it(`convert to base64 and back: '${check}'`, async () => {
+      const b64Str = fromByteArray(
+        mapStr(check, (char: string) => char.charCodeAt(0)),
+      );
+
+      const arr = toByteArray(b64Str);
+      const str = mapArr(arr, (byte: number) => String.fromCharCode(byte));
+      expect(str).to.equal(check);
+      expect(byteLength(b64Str)).to.equal(arr.length);
+    });
+  }
+
+  const test = (data: Uint8Array, expected: string, descr: string) => {
+    it(`known zero values: ${descr}`, async () => {
+      const hex = Buffer.from(data).toString('hex');
+      console.log('hex', hex);
+      const actual = fromByteArray(data);
+      console.log('b64str', actual);
+      expect(actual).to.equal(expected);
+    });
+  };
+
+  // zero
+  const zero = new Uint8Array([122, 101, 114, 111]);
+  test(zero, 'emVybw==', 'zero');
+
+  // zer\0
+  const zer0 = new Uint8Array([122, 101, 114, 0]);
+  test(zer0, 'emVyAA==', 'zer\0');
+
+  // \0er0
+  const ero = new Uint8Array([0, 101, 114, 111]);
+  test(ero, 'AGVybw==', '\0ero');
+
+  // zer\0_value
+  const zer0_value = new Uint8Array([
+    122, 101, 114, 0, 95, 118, 97, 108, 117, 101,
+  ]);
+  test(zer0_value, 'emVyAF92YWx1ZQ==', 'zer\0_value');
+});

--- a/example/src/useTestList.ts
+++ b/example/src/useTestList.ts
@@ -8,6 +8,7 @@ import './tests/basics';
 import './tests/convert';
 import './tests/corrupt';
 import './tests/url-safe';
+import './tests/linebreaks';
 import './tests/zero';
 import './tests/big-data';
 

--- a/example/src/useTestList.ts
+++ b/example/src/useTestList.ts
@@ -8,6 +8,7 @@ import './tests/basics';
 import './tests/convert';
 import './tests/corrupt';
 import './tests/url-safe';
+import './tests/zero';
 import './tests/big-data';
 
 export const useTestList = (): Suites => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-quick-base64",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A native implementation of base64 in C++ for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,14 @@ if (Base64Module && typeof Base64Module.install === 'function') {
   Base64Module.install()
 }
 
-type FuncBase64ToArrayBuffer = (data: string) => ArrayBuffer
-type FuncBase64FromArrayBuffer = (data: string | ArrayBuffer) => string
+type FuncBase64ToArrayBuffer = (
+  data: string,
+  removeLinebreaks?: boolean
+) => ArrayBuffer
+type FuncBase64FromArrayBuffer = (
+  data: string | ArrayBuffer,
+  urlSafe?: boolean
+) => string
 
 declare var base64ToArrayBuffer: FuncBase64ToArrayBuffer | undefined
 declare const base64FromArrayBuffer: FuncBase64FromArrayBuffer | undefined
@@ -56,25 +62,32 @@ export function byteLength(b64: string): number {
   return ((validLen + placeHoldersLen) * 3) / 4 - placeHoldersLen
 }
 
-export function toByteArray(b64: string): Uint8Array {
+export function toByteArray(
+  b64: string,
+  removeLinebreaks: boolean = false
+): Uint8Array {
   if (typeof base64ToArrayBuffer !== 'undefined') {
-    return new Uint8Array(base64ToArrayBuffer(b64))
+    return new Uint8Array(base64ToArrayBuffer(b64, removeLinebreaks))
   } else {
     return fallback.toByteArray(b64)
   }
 }
 
-export function fromByteArray(uint8: Uint8Array): string {
+export function fromByteArray(
+  uint8: Uint8Array,
+  urlSafe: boolean = false
+): string {
   if (typeof base64FromArrayBuffer !== 'undefined') {
     if (uint8.buffer.byteLength > uint8.byteLength || uint8.byteOffset > 0) {
       return base64FromArrayBuffer(
         uint8.buffer.slice(
           uint8.byteOffset,
           uint8.byteOffset + uint8.byteLength
-        )
+        ),
+        urlSafe
       )
     }
-    return base64FromArrayBuffer(uint8.buffer)
+    return base64FromArrayBuffer(uint8.buffer, urlSafe)
   } else {
     return fallback.fromByteArray(uint8)
   }
@@ -103,3 +116,7 @@ export const getNative = () => ({
   base64FromArrayBuffer,
   base64ToArrayBuffer,
 })
+
+export const trimBase64Padding = (str: string): string => {
+  return str.replace(/[.=]{1,2}$/, '')
+}


### PR DESCRIPTION
The `url` boolean flag for `base64_encode()` was not exposed to Javascript side.  This PR exposes that flag as `urlSafe` and adds a couple of tests.

The `removeLinebreaks` flag for `base64_decode()` was not exposed to Javascript side.  This PR exposes that flag as `removeLinebreaks`.

Test were added to ensure proper handling of `\0` characters.

It also adds a `trimBase64Padding` function for tests and general use.