### PR TITLE
fix: npm deployments missing podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "android",
     "ios",
     "cpp",
-    "react-native-quick-crypto.podspec",
+    "react-native-quick-base64.podspec",
     "!lib/typescript/example",
     "!android/build",
     "!ios/build",


### PR DESCRIPTION
NPM deployments have no cocoapod for the package, making it broken on master branch currently. Closes #40 

Would love if we can get a patch release as soon as this gets merged