### PR TITLE
fix: base64 encode sometime use "urlsafe" charset causing issue

### DIFF
--- a/cpp/react-native-quick-base64.cpp
+++ b/cpp/react-native-quick-base64.cpp
@@ -35,11 +35,11 @@ void installBase64(jsi::Runtime& jsiRuntime) {
       1,  // string
       [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
         std::string str;
-        if(!valueToString(runtime, arguments[0], &str)) {
+        if(count > 0 && !valueToString(runtime, arguments[0], &str)) {
           return jsi::Value(-1);
         }
         bool url = false;
-        if (arguments[1].isBool()) {
+        if (count > 1 && arguments[1].isBool()) {
           url = arguments[1].asBool();
         }
         try {
@@ -59,13 +59,13 @@ void installBase64(jsi::Runtime& jsiRuntime) {
       jsi::PropNameID::forAscii(jsiRuntime, "base64ToArrayBuffer"),
       1,  // string
       [](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (!arguments[0].isString()) {
+        if (count > 0 && !arguments[0].isString()) {
           return jsi::Value(-1);
         }
 
         std::string strBase64 = arguments[0].getString(runtime).utf8(runtime);
         bool removeLinebreaks = false;
-        if (arguments[1].isBool()) {
+        if (count > 1 && arguments[1].isBool()) {
           removeLinebreaks = arguments[1].asBool();
         }
         try {

--- a/example/src/tests/url-safe.ts
+++ b/example/src/tests/url-safe.ts
@@ -40,7 +40,7 @@ describe('url-safe', () => {
       'base64 encode (url=true, trimmed)'
     )
     expect(actual).to.equal(
-      expected + '.',
+      expected,
       'base64 encode (url=true, not trimmed)'
     )
   })

--- a/example/src/tests/url-safe.ts
+++ b/example/src/tests/url-safe.ts
@@ -39,10 +39,7 @@ describe('url-safe', () => {
       expected,
       'base64 encode (url=true, trimmed)'
     )
-    expect(actual).to.equal(
-      expected,
-      'base64 encode (url=true, not trimmed)'
-    )
+    expect(actual).to.equal(expected, 'base64 encode (url=true, not trimmed)')
   })
 
   it('encode/decode base64 string w padding', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export function fromByteArray(
  * @deprecated Use native btoa() instead - now supported in Hermes
  */
 export function btoa(data: string) {
-  return global.base64FromArrayBuffer(stringToArrayBuffer(data))
+  return global.base64FromArrayBuffer(stringToArrayBuffer(data), false)
 }
 
 /**


### PR DESCRIPTION
Sometime, react-native-quick-base64 use "url safe" charset in `btoa` function (`base64FromArrayBuffer` call inside should not use url safe !). 
That result in leading padding character `.` (instead of `=`) which is uncommon/unexpected. Or usage of `-` `_` instead of `/` `+`.

I suspect that `base64FromArrayBuffer` `arguments[1]` is sometime `true` even if not provided. maybe read a random value in the runtime stack (due to pointer), because `arguments[1]` is optional.

To patch that:
* I remove the usage of `.` (did not exist in base64 spec !), and remove padding in urlsafe. See https://github.com/heifner/base64/pull/3 for inspiration.
* In `btoa`, I add explicitly `urlSafe=false` into `base64FromArrayBuffer` call.
* In `base64FromArrayBuffer` cpp impl, I check `arguments` size before using it (to ensure to not use a random value on the runtime stack, my suspicion)

I tested it on my application where multiple users has this issue with base64 encoding with `btoa`.
This fixes https://github.com/craftzdog/react-native-quick-base64/issues/44