### PR TITLE
perf: use getStringData to avoid UTF-16→UTF-8 re-encoding on decode

### DIFF
--- a/cpp/react-native-quick-base64.cpp
+++ b/cpp/react-native-quick-base64.cpp
@@ -63,7 +63,19 @@ void installBase64(jsi::Runtime& jsiRuntime) {
           return jsi::Value(-1);
         }
 
-        std::string strBase64 = arguments[0].getString(runtime).utf8(runtime);
+        std::string strBase64;
+        auto cb = [&strBase64](bool ascii, const void* data, size_t num) {
+          if (ascii) {
+            strBase64.append(static_cast<const char*>(data), num);
+          } else {
+            const auto* u16 = static_cast<const char16_t*>(data);
+            strBase64.reserve(strBase64.size() + num);
+            for (size_t i = 0; i < num; i++) {
+              strBase64.push_back(static_cast<char>(u16[i]));
+            }
+          }
+        };
+        arguments[0].asString(runtime).getStringData(runtime, cb);
         bool removeLinebreaks = false;
         if (count > 1 && arguments[1].isBool()) {
           removeLinebreaks = arguments[1].asBool();


### PR DESCRIPTION
Replace .utf8(runtime) in base64ToArrayBuffer with jsi::String::getStringData, which exposes Hermes's internal string representation directly. Base64 strings are always ASCII, so Hermes stores them as compact byte arrays; the ascii=true branch is a near-zero-overhead copy with no encoding step. The ascii=false fallback handles the UTF-16 case by downcasting each char16_t to char, which is safe because all base64 characters fit in the ASCII range.

## Screenshots
| Android emulator | iPhone 16e simulator |
| - | - |
| <img src="https://github.com/user-attachments/assets/2eb866aa-5b21-4c9f-9794-d02fc564ccdb" width=300 /> | <img src="https://github.com/user-attachments/assets/48940be1-ba50-42fe-9e9b-ff2432ea1f6e" width=300 /> |
